### PR TITLE
Fix request independence problems

### DIFF
--- a/lib/cartodb/api.rb
+++ b/lib/cartodb/api.rb
@@ -32,10 +32,18 @@ module CartoDB
         @@default_configuration = configuration
       end
 
+      def build_configuration(configuration = nil)
+        if configuration
+          default_configuration.dup.merge(configuration)
+        else
+          default_configuration.dup
+        end
+      end
+
       protected
 
       def build_request(configuration = nil)
-        configuration = configuration ? default_configuration.merge(configuration) : default_configuration.dup
+        configuration = build_configuration(configuration)
         CartoDB::Api::Request.new(configuration)
       end
 
@@ -44,7 +52,6 @@ module CartoDB
       def default_configuration
         @@default_configuration ||= CartoDB::Api::Configuration.new
       end
-
     end
   end
 end

--- a/lib/cartodb/api/error.rb
+++ b/lib/cartodb/api/error.rb
@@ -1,16 +1,35 @@
 module CartoDB
   module Api
-    class ConnectionFailed < StandardError
-    end
-
-    class InvalidConfiguration < StandardError
-    end
-
-    class Error < StandardError
+    class CartoDBError < StandardError
       attr_accessor :title, :details, :body, :raw_body, :status_code
     end
 
-    class ParsingError < Error
+    class ConnectionFailed < CartoDBError
+    end
+
+    class InvalidConfiguration < CartoDBError
+    end
+
+    class ApiError < CartoDBError
+      def to_s
+        whole_message = "the server responded with status #{status_code}"
+        whole_message = append_to_message(whole_message, title)
+        whole_message = append_to_message(whole_message, details)
+        append_to_message(whole_message, body)
+      end
+
+      private
+
+      def append_to_message(message, text)
+        if text && !text.empty?
+          "#{message}\n#{text}"
+        else
+          message
+        end
+      end
+    end
+
+    class ParsingError < ApiError
     end
   end
 end


### PR DESCRIPTION
#### What's this PR do?

It fixes a bug related to using a `Request` object for multiple requests. It also improves the error messages given by `ApiError`.
#### How should this be manually tested?

Taken from Issue #4
Assuming you have already created and set a default configuration:

``` ruby
cartodb = CartoDB::Api::Request.new
cartodb.sql.retrieve params: {q: "SELECT * FROM foo"}
```
#### What are the relevant tickets?

Fixes #4 regarding the multiple requests 
 Fixes #5 regarding clearer error messages
